### PR TITLE
Helm chart metrics server

### DIFF
--- a/eks/metrics-server.tf
+++ b/eks/metrics-server.tf
@@ -1,0 +1,9 @@
+resource "helm_release" "metrics-server" {
+  count      = var.metrics_server_enabled ? 1 : 0
+  name       = metrics-server
+  repository = "https://charts.bitnami.com/bitnami"
+  chart      = "bitnami/metrics-server"
+  version    = var.metrics_server_version
+  namespace  = "kube-system"
+  wait       = false
+}

--- a/eks/variables.tf
+++ b/eks/variables.tf
@@ -371,3 +371,11 @@ variable "fargate_selector" {
     },
   }
 }
+
+variable "metrics_server_enabled" {
+  default = true
+}
+
+variable "metrics_server_version" {
+  default = "5.9.3"
+}


### PR DESCRIPTION
There is no official helm chart for metrics, so it's good to use the metrics server helm chart from bitnami 